### PR TITLE
Upgrade to latest sbl sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,14 @@
 
     ```bash
     wget https://developer.arm.com/-/media/Files/downloads/gnu-a/10.3-2021.07/binrel/gcc-arm-10.3-2021.07-x86_64-aarch64-none-elf.tar.xz
-    tar xzf gcc-arm-10.3-2021.07-x86_64-aarch64-none-elf.tar.xz -C /opt/
+    tar -C /opt/ -xvf gcc-arm-10.3-2021.07-x86_64-aarch64-none-elf.tar.xz
     ```
 
     ```bash
-    wget TBD/toolchain-mipsel-elvees-elf32.tar.xz
-    tar xzf toolchain-mipsel-elvees-elf32.tar.xz -C /opt/
+    wget https://dist.elvees.com/mcom03/buildroot/2022.06/rockpi/images/aarch64-buildroot-linux-gnu_sdk-buildroot.tar.gz
+    tar -C /opt/ -xvzf aarch64-buildroot-linux-gnu_sdk-buildroot.tar.gz \
+        aarch64-buildroot-linux-gnu_sdk-buildroot/opt/toolchain-mipsel-elvees-elf32/ \
+        --strip-components=2
     ```
 
 4. Запустите сборку в контейнере

--- a/build.sh
+++ b/build.sh
@@ -27,7 +27,7 @@ function dl_repo()
 
 function dl_src()
 {
-    bin/repo init -u https://github.com/dpetrov-rts/mcom03-sbl-build \
+    bin/repo init -u https://github.com/dis-projects/mcom03-sbl-build \
         -b master -m default.xml
     bin/repo sync
 }

--- a/build.sh
+++ b/build.sh
@@ -132,7 +132,7 @@ function build_mcom03_sbl()
     pushd sources/mcom03-sbl
     unset_env
     mkdir -p build && cd build
-    cp ../link.ld .
+    ln -s ../link.ld link.ld
     cmake .. \
         -DCMAKE_TRY_COMPILE_TARGET_TYPE="STATIC_LIBRARY" \
         -DDDRINIT_PATH=../../ddrinit/src/ddrinit.bin \

--- a/build.sh
+++ b/build.sh
@@ -6,14 +6,15 @@ set -eu -o pipefail
 # Download GCC ARM64 toolchain from
 #   https://developer.arm.com/-/media/Files/downloads/gnu-a/10.3-2021.07/binrel/gcc-arm-10.3-2021.07-x86_64-aarch64-none-elf.tar.xz
 # Extract it somewhere to disk, e.g.
-#   tar -C /opt/ -xf gcc-arm-10.3-2021.07-x86_64-aarch64-none-elf.tar.xz
+#   tar -C /opt/ -xvf gcc-arm-10.3-2021.07-x86_64-aarch64-none-elf.tar.xz
 # Provide the full path here:
 GCC_ARM="/opt/gcc-arm-10.3-2021.07-x86_64-aarch64-none-elf/"
 
-# Download buildroot sources for MCom-03 from
-#   https://dist.elvees.com/mcom03/buildroot/20220420/rockpi/mcom03-defconfig-src.tar.gz
-# Extract Elvees MIPS toolchain somewhere to disk, e.g.
-#   tar -C /opt/ -xzf buildroot/dl/toolchain-mipsel-elvees-elf32/MCom03-console-SDK.linux64.2022-01-17.tar.gz MCom03-SDK/gcc-mipsel-elf32_linux/
+# Download MCom-03 SDK from
+#   https://dist.elvees.com/mcom03/buildroot/2022.06/rockpi/images/aarch64-buildroot-linux-gnu_sdk-buildroot.tar.gz
+# Extract it somewhere to disk, e.g.
+#   tar -C /opt/ -xvzf aarch64-buildroot-linux-gnu_sdk-buildroot.tar.gz \
+#   aarch64-buildroot-linux-gnu_sdk-buildroot/opt/toolchain-mipsel-elvees-elf32/ --strip-components=2
 # and provide the full path here:
 GCC_MIPS="/opt/toolchain-mipsel-elvees-elf32/"
 

--- a/build.sh
+++ b/build.sh
@@ -32,16 +32,6 @@ function dl_src()
     bin/repo sync
 }
 
-function dl_gcc_arm()
-{
-    local GCC_ARM_VER
-    GCC_ARM_VER=$(echo $GCC_ARM | cut -d'-' -f 3-4)
-    local GCC_ARM_TAR="${GCC_ARM}.tar.xz"
-    curl -L "https://developer.arm.com/-/media/Files/downloads/gnu-a/${GCC_ARM_VER}/binrel/${GCC_ARM_TAR}" -o "${GCC_ARM_TAR}"
-    tar xf "${GCC_ARM_TAR}" -C /opt
-    rm "${GCC_ARM_TAR}"
-}
-
 function set_env_arm()
 {
     export ARCH=aarch64

--- a/default.xml
+++ b/default.xml
@@ -5,16 +5,16 @@
   <default sync-j="4"/>
 
   <project name="mcom03-sbl" path="sources/mcom03-sbl"
-           remote="elvees-github" revision="99b473c982a3419e44ed1461c237ba9928692405"/>
+           remote="elvees-github" revision="986d27809dce806c63bf1793498562ebb86e6d4f"/>
 
   <project name="ddrinit" path="sources/ddrinit"
-           remote="elvees-github" revision="11bb2cec5ec5e63bb8bcb66ba5c00521490feb21"/>
+           remote="elvees-github" revision="f0509e87294e237c36f9778625d12ae5141df7d7"/>
 
   <project name="arm-trusted-firmware" path="sources/arm-trusted-firmware"
            remote="elvees-github" revision="fae73641e08216a956cecd7b0af9b1f6beaa6eca"/>
 
   <project name="u-boot" path="sources/u-boot"
-           remote="elvees-github" revision="6a981f06369fd39c529980da95e1d718a87323f4"/>
+           remote="elvees-github" revision="72a0c32d1152707f4f61e70dbb52ecc50ff29693"/>
 
   <project name="mcom03-flash-tools" path="sources/mcom03-flash-tools"
            remote="elvees-github" revision="47723b95ac324b7ebe9a9a38a347475b3dafea0e"/>


### PR DESCRIPTION
Now you can build the latest version of sbl using the new toolchain.